### PR TITLE
change config data "pci_bdf" in all LNT to "lnt_pci_bdf"

### DIFF
--- a/tests/LNT_ECMP_2HotPlugVM_2Host_netperf.py
+++ b/tests/LNT_ECMP_2HotPlugVM_2Host_netperf.py
@@ -64,7 +64,7 @@ class LNT_ECMP_2HotPlugVM_2Host_Netperf(BaseTest):
 
         self.config_data = get_config_dict(
             config_json,
-            pci_bdf=test_params["pci_bdf"],
+            pci_bdf=test_params["lnt_pci_bdf"],
             vm_location_list=test_params["vm_location_list"],
             vm_cred=self.vm_cred,
             client_cred=test_params["client_cred"],
@@ -87,8 +87,6 @@ class LNT_ECMP_2HotPlugVM_2Host_Netperf(BaseTest):
         log.info("Begin to configure OVS and VM on local host")
         # Create VM
         result, vm_name = test_utils.vm_create_with_hotplug(self.config_data)
-        log.info(result)
-        log.info(vm_name)
         if not result:
             self.result.addFailure(self, sys.exc_info())
             self.fail(f"Failed to create {vm_name}")
@@ -211,7 +209,7 @@ class LNT_ECMP_2HotPlugVM_2Host_Netperf(BaseTest):
         ):
             self.result.addFailure(self, sys.exc_info())
             self.fail("Failed to generate P4C artifacts or pb.bin")
-
+        
         # Run Set-pipe command for set pipeline
         if not p4rt_ctl.p4rt_ctl_set_pipe(
             self.config_data["switch"],
@@ -739,11 +737,6 @@ class LNT_ECMP_2HotPlugVM_2Host_Netperf(BaseTest):
                 self.fail(
                     f"Failed to delete VM namesapce {namespace['name']} on {self.config_data['client_hostname']}"
                 )
-
-        # remove local bridge
-        if not ovs_utils.del_bridge_from_ovs(self.config_data["bridge"]):
-            self.result.addFailure(self, sys.exc_info())
-            self.fail(f"Failed to delete bridge {self.config_data['bridge']} from ovs")
 
         # remote bridge
         if not ovs_utils.del_bridge_from_ovs(

--- a/tests/LNT_ECMP_2VM_2Host_del_add.py
+++ b/tests/LNT_ECMP_2VM_2Host_del_add.py
@@ -59,7 +59,7 @@ class LNT_ECMP_DEL_ADD_RULE(BaseTest):
 
         self.config_data = get_config_dict(
             config_json,
-            pci_bdf=test_params["pci_bdf"],
+            pci_bdf=test_params["lnt_pci_bdf"],
             vm_location_list=test_params["vm_location_list"],
             vm_cred=self.vm_cred,
             client_cred=test_params["client_cred"],
@@ -75,10 +75,10 @@ class LNT_ECMP_DEL_ADD_RULE(BaseTest):
         # Generate p4c artifact and create binary by using tdi pna arch
         if not test_utils.gen_dep_files_p4c_dpdk_pna_tdi_pipeline_builder(
             self.config_data
-        ):
+        ):  
             self.result.addFailure(self, sys.exc_info())
             self.fail("Failed to generate P4C artifacts or pb.bin")
-
+        
         # Create ports using gnmi-ctl
         if not gnmi_ctl_utils.gnmi_ctl_set_and_verify(self.gnmictl_params):
             self.result.addFailure(self, sys.exc_info())
@@ -445,7 +445,7 @@ class LNT_ECMP_DEL_ADD_RULE(BaseTest):
             conn.close()
 
     def tearDown(self):
-
+       
         log.info("Unconfiguration on local host")
         log.info(f"Delete p4ovs match action rules on local host")
         for table in self.config_data["table"]:
@@ -502,12 +502,7 @@ class LNT_ECMP_DEL_ADD_RULE(BaseTest):
                     f"Failed to delete VM namesapce {namespace['name']} on {self.config_data['client_hostname']}"
                 )
 
-        # remove local bridge
-        if not ovs_utils.del_bridge_from_ovs(self.config_data["bridge"]):
-            self.result.addFailure(self, sys.exc_info())
-            self.fail(f"Failed to delete bridge {self.config_data['bridge']} from ovs")
-
-        # remote bridge
+        # delete remote bridge
         if not ovs_utils.del_bridge_from_ovs(
             self.config_data["bridge"],
             remote=True,

--- a/tests/LNT_ECMP_2VM_2Host_hotplug.py
+++ b/tests/LNT_ECMP_2VM_2Host_hotplug.py
@@ -60,7 +60,7 @@ class LNT_ECMP_2VM_Hotplug(BaseTest):
 
         self.config_data = get_config_dict(
             config_json,
-            pci_bdf=test_params["pci_bdf"],
+            pci_bdf=test_params["lnt_pci_bdf"],
             vm_location_list=test_params["vm_location_list"],
             vm_cred=self.vm_cred,
             client_cred=test_params["client_cred"],
@@ -581,12 +581,7 @@ class LNT_ECMP_2VM_Hotplug(BaseTest):
                     f"Failed to delete VM namesapce {namespace['name']} on {self.config_data['client_hostname']}"
                 )
 
-        # remove local bridge
-        if not ovs_utils.del_bridge_from_ovs(self.config_data["bridge"]):
-            self.result.addFailure(self, sys.exc_info())
-            self.fail(f"Failed to delete bridge {self.config_data['bridge']} from ovs")
-
-        # remote bridge
+        # delete remote bridge
         if not ovs_utils.del_bridge_from_ovs(
             self.config_data["bridge"],
             remote=True,

--- a/tests/LNT_ECMP_2VM_2Host_link_flap_netperf.py
+++ b/tests/LNT_ECMP_2VM_2Host_link_flap_netperf.py
@@ -59,7 +59,7 @@ class LNT_ECMP_2VM_2Host_Link_Flap(BaseTest):
 
         self.config_data = get_config_dict(
             config_json,
-            pci_bdf=test_params["pci_bdf"],
+            pci_bdf=test_params["lnt_pci_bdf"],
             vm_location_list=test_params["vm_location_list"],
             vm_cred=self.vm_cred,
             client_cred=test_params["client_cred"],
@@ -747,12 +747,7 @@ class LNT_ECMP_2VM_2Host_Link_Flap(BaseTest):
                     f"Failed to delete VM namesapce {namespace['name']} on {self.config_data['client_hostname']}"
                 )
 
-        # Remove local bridge
-        if not ovs_utils.del_bridge_from_ovs(self.config_data["bridge"]):
-            self.result.addFailure(self, sys.exc_info())
-            self.fail(f"Failed to delete bridge {self.config_data['bridge']} from ovs")
-
-        # Remote remote bridge
+        # Delete remote bridge
         if not ovs_utils.del_bridge_from_ovs(
             self.config_data["bridge"],
             remote=True,

--- a/tests/LNT_ECMP_2VM_2Host_netperf.py
+++ b/tests/LNT_ECMP_2VM_2Host_netperf.py
@@ -59,7 +59,7 @@ class LNT_ECMP_2VM_2Host_netperf(BaseTest):
 
         self.config_data = get_config_dict(
             config_json,
-            pci_bdf=test_params["pci_bdf"],
+            pci_bdf=test_params["lnt_pci_bdf"],
             vm_location_list=test_params["vm_location_list"],
             vm_cred=self.vm_cred,
             client_cred=test_params["client_cred"],
@@ -684,12 +684,7 @@ class LNT_ECMP_2VM_2Host_netperf(BaseTest):
                     f"Failed to delete VM namesapce {namespace['name']} on {self.config_data['client_hostname']}"
                 )
 
-        # Remove local bridge
-        if not ovs_utils.del_bridge_from_ovs(self.config_data["bridge"]):
-            self.result.addFailure(self, sys.exc_info())
-            self.fail(f"Failed to delete bridge {self.config_data['bridge']} from ovs")
-
-        # Remote remote bridge
+        # Delete remote bridge
         if not ovs_utils.del_bridge_from_ovs(
             self.config_data["bridge"],
             remote=True,

--- a/tests/LNT_FRR_with_ECMP_Hotplug_netperf.py
+++ b/tests/LNT_FRR_with_ECMP_Hotplug_netperf.py
@@ -62,7 +62,7 @@ class LNT_FRR_with_ECMP_Hotplug_netperf(BaseTest):
 
         self.config_data = get_config_dict(
             config_json,
-            pci_bdf=test_params["pci_bdf"],
+            pci_bdf=test_params["lnt_pci_bdf"],
             vm_location_list=test_params["vm_location_list"],
             vm_cred=self.vm_cred,
             client_cred=test_params["client_cred"],
@@ -795,12 +795,7 @@ class LNT_FRR_with_ECMP_Hotplug_netperf(BaseTest):
                     f"Failed to delete VM namesapce {namespace['name']} on {self.config_data['client_hostname']}"
                 )
 
-        # Remove local bridge
-        if not ovs_utils.del_bridge_from_ovs(self.config_data["bridge"]):
-            self.result.addFailure(self, sys.exc_info())
-            self.fail(f"Failed to delete bridge {self.config_data['bridge']} from ovs")
-
-        # Remote remote bridge
+        # Delete remote bridge
         if not ovs_utils.del_bridge_from_ovs(
             self.config_data["bridge"],
             remote=True,

--- a/tests/LNT_FRR_with_ECMP_modify_BGP_ASN.py
+++ b/tests/LNT_FRR_with_ECMP_modify_BGP_ASN.py
@@ -58,7 +58,7 @@ class LNT_FRR_with_ECMP_modify_BGP_ASN(BaseTest):
 
         self.config_data = get_config_dict(
             config_json,
-            pci_bdf=test_params["pci_bdf"],
+            pci_bdf=test_params["lnt_pci_bdf"],
             vm_location_list=test_params["vm_location_list"],
             vm_cred=self.vm_cred,
             client_cred=test_params["client_cred"],
@@ -659,12 +659,7 @@ class LNT_FRR_with_ECMP_modify_BGP_ASN(BaseTest):
                     f"Failed to delete VM namesapce {namespace['name']} on {self.config_data['client_hostname']}"
                 )
 
-        # Remove local bridge
-        if not ovs_utils.del_bridge_from_ovs(self.config_data["bridge"]):
-            self.result.addFailure(self, sys.exc_info())
-            self.fail(f"Failed to delete bridge {self.config_data['bridge']} from ovs")
-
-        # Remote bridge
+        # Delete remote bridge
         if not ovs_utils.del_bridge_from_ovs(
             self.config_data["bridge"],
             remote=True,

--- a/tests/LNT_FRR_with_ECMP_modify_TEP_IP.py
+++ b/tests/LNT_FRR_with_ECMP_modify_TEP_IP.py
@@ -57,7 +57,7 @@ class LNT_FRR_with_ECMP_modify_TEP_IP(BaseTest):
 
         self.config_data = get_config_dict(
             config_json,
-            pci_bdf=test_params["pci_bdf"],
+            pci_bdf=test_params["lnt_pci_bdf"],
             vm_location_list=test_params["vm_location_list"],
             vm_cred=self.vm_cred,
             client_cred=test_params["client_cred"],
@@ -769,12 +769,7 @@ class LNT_FRR_with_ECMP_modify_TEP_IP(BaseTest):
                     f"Failed to delete VM namesapce {namespace['name']} on {self.config_data['client_hostname']}"
                 )
 
-        # Remove local bridge
-        if not ovs_utils.del_bridge_from_ovs(self.config_data["bridge"]):
-            self.result.addFailure(self, sys.exc_info())
-            self.fail(f"Failed to delete bridge {self.config_data['bridge']} from ovs")
-
-        # Remote remote bridge
+        # Delete remote bridge
         if not ovs_utils.del_bridge_from_ovs(
             self.config_data["bridge"],
             remote=True,

--- a/tests/LNT_FRR_with_ECMP_netperf_LinkFlap.py
+++ b/tests/LNT_FRR_with_ECMP_netperf_LinkFlap.py
@@ -58,7 +58,7 @@ class LNT_FRR_with_ECMP_netperf_flap(BaseTest):
 
         self.config_data = get_config_dict(
             config_json,
-            pci_bdf=test_params["pci_bdf"],
+            pci_bdf=test_params["lnt_pci_bdf"],
             vm_location_list=test_params["vm_location_list"],
             vm_cred=self.vm_cred,
             client_cred=test_params["client_cred"],
@@ -722,12 +722,7 @@ class LNT_FRR_with_ECMP_netperf_flap(BaseTest):
                     f"Failed to delete VM namesapce {namespace['name']} on {self.config_data['client_hostname']}"
                 )
 
-        # Remove local bridge
-        if not ovs_utils.del_bridge_from_ovs(self.config_data["bridge"]):
-            self.result.addFailure(self, sys.exc_info())
-            self.fail(f"Failed to delete bridge {self.config_data['bridge']} from ovs")
-
-        # Remote remote bridge
+        # Delete remote bridge
         if not ovs_utils.del_bridge_from_ovs(
             self.config_data["bridge"],
             remote=True,

--- a/tests/LNT_FRR_with_ECMP_ping_10min.py
+++ b/tests/LNT_FRR_with_ECMP_ping_10min.py
@@ -58,7 +58,7 @@ class LNT_FRR_with_ECMP_ping_10min(BaseTest):
 
         self.config_data = get_config_dict(
             config_json,
-            pci_bdf=test_params["pci_bdf"],
+            pci_bdf=test_params["lnt_pci_bdf"],
             vm_location_list=test_params["vm_location_list"],
             vm_cred=self.vm_cred,
             client_cred=test_params["client_cred"],
@@ -557,13 +557,8 @@ class LNT_FRR_with_ECMP_ping_10min(BaseTest):
                 self.fail(
                     f"Failed to delete VM namesapce {namespace['name']} on {self.config_data['client_hostname']}"
                 )
-
-        # Remove local bridge
-        if not ovs_utils.del_bridge_from_ovs(self.config_data["bridge"]):
-            self.result.addFailure(self, sys.exc_info())
-            self.fail(f"Failed to delete bridge {self.config_data['bridge']} from ovs")
-
-        # Remove remote bridge
+                
+        # Delete remote bridge
         if not ovs_utils.del_bridge_from_ovs(
             self.config_data["bridge"],
             remote=True,

--- a/tests/LNT_FRR_without_ECMP_netperf.py
+++ b/tests/LNT_FRR_without_ECMP_netperf.py
@@ -58,7 +58,7 @@ class LNT_FRR_without_ECMP_Netperf(BaseTest):
 
         self.config_data = get_config_dict(
             config_json,
-            pci_bdf=test_params["pci_bdf"],
+            pci_bdf=test_params["lnt_pci_bdf"],
             vm_location_list=test_params["vm_location_list"],
             vm_cred=self.vm_cred,
             client_cred=test_params["client_cred"],
@@ -646,7 +646,7 @@ class LNT_FRR_without_ECMP_Netperf(BaseTest):
             conn.close()
 
     def tearDown(self):
-
+        
         log.info("Unconfiguration on local host")
         log.info(f"Delete match action rules on local host")
         for table in self.config_data["table"]:
@@ -694,12 +694,7 @@ class LNT_FRR_without_ECMP_Netperf(BaseTest):
                     f"Failed to delete VM namesapce {namespace['name']} on {self.config_data['client_hostname']}"
                 )
 
-        # remove local bridge
-        if not ovs_utils.del_bridge_from_ovs(self.config_data["bridge"]):
-            self.result.addFailure(self, sys.exc_info())
-            self.fail(f"Failed to delete bridge {self.config_data['bridge']} from ovs")
-
-        # remote bridge
+        # delete remote bridge
         if not ovs_utils.del_bridge_from_ovs(
             self.config_data["bridge"],
             remote=True,

--- a/tests/LNT_FRR_without_ECMP_ping_10min_LinkFlap.py
+++ b/tests/LNT_FRR_without_ECMP_ping_10min_LinkFlap.py
@@ -58,7 +58,7 @@ class LNT_FRR_without_ECMP_ping_10min_flap(BaseTest):
 
         self.config_data = get_config_dict(
             config_json,
-            pci_bdf=test_params["pci_bdf"],
+            pci_bdf=test_params["lnt_pci_bdf"],
             vm_location_list=test_params["vm_location_list"],
             vm_cred=self.vm_cred,
             client_cred=test_params["client_cred"],
@@ -621,12 +621,7 @@ class LNT_FRR_without_ECMP_ping_10min_flap(BaseTest):
                     f"Failed to delete VM namesapce {namespace['name']} on {self.config_data['client_hostname']}"
                 )
 
-        # remove local bridge
-        if not ovs_utils.del_bridge_from_ovs(self.config_data["bridge"]):
-            self.result.addFailure(self, sys.exc_info())
-            self.fail(f"Failed to delete bridge {self.config_data['bridge']} from ovs")
-
-        # remote bridge
+        # delete remote bridge
         if not ovs_utils.del_bridge_from_ovs(
             self.config_data["bridge"],
             remote=True,

--- a/tests/LNT_Hot_Plug_Add_Remove_multi_port.py
+++ b/tests/LNT_Hot_Plug_Add_Remove_multi_port.py
@@ -260,11 +260,6 @@ class LNT_Hot_Plug(BaseTest):
             for del_action in table["del_action"]:
                 p4rt_ctl.p4rt_ctl_del_entry(table["switch"], table["name"], del_action)
 
-        # Delete bridge
-        if not ovs_utils.del_bridge_from_ovs(self.config_data["bridge"]):
-            self.result.addFailure(self, sys.exc_info())
-            self.fail(f"Failed to delete bridge {self.config_data['bridge']} from ovs")
-
         # Delete vlan
         for i in range(2):
             id = self.config_data["port"][i]["vlan"]

--- a/tests/LNT_Hot_Plug_Add_Remove_multiple_times.py
+++ b/tests/LNT_Hot_Plug_Add_Remove_multiple_times.py
@@ -319,11 +319,6 @@ class LNT_Hot_Plug(BaseTest):
             for del_action in table["del_action"]:
                 p4rt_ctl.p4rt_ctl_del_entry(table["switch"], table["name"], del_action)
 
-        # Delete bridge
-        if not ovs_utils.del_bridge_from_ovs(self.config_data["bridge"]):
-            self.result.addFailure(self, sys.exc_info())
-            self.fail(f"Failed to delete bridge {self.config_data['bridge']} from ovs")
-
         # Delete vlan
         for i in range(2):
             id = self.config_data["port"][i]["vlan"]

--- a/tests/l3_dpdk_port_flapping_with_link_ports.py
+++ b/tests/l3_dpdk_port_flapping_with_link_ports.py
@@ -228,7 +228,16 @@ class Dpdk_Link_Flapping(BaseTest):
         portconfig_obj.Ip.iplink_enable_disable_link(
             phy_interface1, status_to_change="up"
         )
-
+       
+        # Now Add neighbour entry
+        log.info("Add neigh entry on  PHY1 interface...")
+        portconfig_obj = port_config.PortConfig()
+        portconfig_obj.Ip.ip_neigh_add(
+            phy_interface1,
+            self.config_data["port"][1]["remote_ip"],
+            self.config_data["port"][1]["mac_local"],
+        )
+        
         # ping test between VM to link port after up the port
         time.sleep(5)
         log.info("----------------------------------------------------------------")

--- a/tests/lnt_1hotplugvm_vxlan_1nsvm.py
+++ b/tests/lnt_1hotplugvm_vxlan_1nsvm.py
@@ -60,7 +60,7 @@ class LNT_1HotplugVM_Vxlan_1NsVM(BaseTest):
 
         self.config_data = get_config_dict(
             config_json,
-            pci_bdf=test_params["pci_bdf"],
+            pci_bdf=test_params["lnt_pci_bdf"],
             vm_location_list=test_params["vm_location_list"],
             vm_cred=self.vm_cred,
             client_cred=test_params["client_cred"],
@@ -81,8 +81,6 @@ class LNT_1HotplugVM_Vxlan_1NsVM(BaseTest):
         # Creat VM
         log.info(f"Begin to configure P4ORT and VM on local host")
         result, vm_name = test_utils.vm_create_with_hotplug(self.config_data)
-        log.info(result)
-        log.info(vm_name)
         if not result:
             self.result.addFailure(self, sys.exc_info())
             self.fail(f"Failed to create {vm_name}")
@@ -172,7 +170,7 @@ class LNT_1HotplugVM_Vxlan_1NsVM(BaseTest):
         ):
             self.result.addFailure(self, sys.exc_info())
             self.fail("Failed to generate P4C artifacts or pb.bin")
-
+        
         # Set pipe line
         if not p4rt_ctl.p4rt_ctl_set_pipe(
             self.config_data["switch"],
@@ -370,7 +368,7 @@ class LNT_1HotplugVM_Vxlan_1NsVM(BaseTest):
                 f"Failed to add physical port {self.config_data['remote_port'][0]} to \
                               bridge {self.config_data['bridge']} on {self.config_data['client_hostname']}"
             )
-
+       
         # --------------------------------- #
         #     Both VM ping each other       #
         # ----------------------------------#
@@ -438,11 +436,6 @@ class LNT_1HotplugVM_Vxlan_1NsVM(BaseTest):
                 self.fail(
                     f"Failed to delete VM namesapce {namespace['name']} on {self.config_data['client_hostname']}"
                 )
-
-        # Remove local bridge
-        if not ovs_utils.del_bridge_from_ovs(self.config_data["bridge"]):
-            self.result.addFailure(self, sys.exc_info())
-            self.fail(f"Failed to delete bridge {self.config_data['bridge']} from ovs")
 
         # Remote remote bridge
         if not ovs_utils.del_bridge_from_ovs(

--- a/tests/lnt_2hotplugvm_vxlan_2nsvm.py
+++ b/tests/lnt_2hotplugvm_vxlan_2nsvm.py
@@ -61,7 +61,7 @@ class LNT_2HotplugVM_VXLAN_2NsVM(BaseTest):
 
         self.config_data = get_config_dict(
             config_json,
-            pci_bdf=test_params["pci_bdf"],
+            pci_bdf=test_params["lnt_pci_bdf"],
             vm_location_list=test_params["vm_location_list"],
             vm_cred=self.vm_cred,
             client_cred=test_params["client_cred"],
@@ -81,8 +81,6 @@ class LNT_2HotplugVM_VXLAN_2NsVM(BaseTest):
         # ------------------------------------------------- #
         log.info("Begin to configure OVS and VM on local host")
         result, vm_name = test_utils.vm_create_with_hotplug(self.config_data)
-        log.info(result)
-        log.info(vm_name)
         if not result:
             self.result.addFailure(self, sys.exc_info())
             self.fail(f"Failed to create {vm_name}")
@@ -189,7 +187,7 @@ class LNT_2HotplugVM_VXLAN_2NsVM(BaseTest):
         ):
             self.result.addFailure(self, sys.exc_info())
             self.fail("Failed to generate P4C artifacts or pb.bin")
-
+    
         # set pipe line
         if not p4rt_ctl.p4rt_ctl_set_pipe(
             self.config_data["switch"],
@@ -445,11 +443,6 @@ class LNT_2HotplugVM_VXLAN_2NsVM(BaseTest):
                 self.fail(
                     f"Failed to delete VM namesapce {namespace['name']} on {self.config_data['client_hostname']}"
                 )
-
-        # remove local bridge
-        if not ovs_utils.del_bridge_from_ovs(self.config_data["bridge"]):
-            self.result.addFailure(self, sys.exc_info())
-            self.fail(f"Failed to delete bridge {self.config_data['bridge']} from ovs")
 
         # remote bridge
         if not ovs_utils.del_bridge_from_ovs(

--- a/tests/lnt_2vm_vxlan_2nsvm_5min_ping.py
+++ b/tests/lnt_2vm_vxlan_2nsvm_5min_ping.py
@@ -61,7 +61,7 @@ class LNT_2vm_vxlan_2nsvm_5min_ping(BaseTest):
 
         self.config_data = get_config_dict(
             config_json,
-            pci_bdf=test_params["pci_bdf"],
+            pci_bdf=test_params["lnt_pci_bdf"],
             vm_location_list=test_params["vm_location_list"],
             vm_cred=self.vm_cred,
             client_cred=test_params["client_cred"],
@@ -80,11 +80,6 @@ class LNT_2vm_vxlan_2nsvm_5min_ping(BaseTest):
         # Configure OVS, VM, VLAN adn VXLAN on Local Host #
         # ------------------------------------------------- #
         log.info(f"Begin to configure OVVS and VM on local host")
-        """
-        if not test_utils.gen_dep_files_p4c_dpdk_pna_ovs_pipeline_builder(self.config_data):
-            self.result.addFailure(self, sys.exc_info())
-            self.fail("Failed to generate P4C artifacts or pb.bin")
-        """
         if not gnmi_ctl_utils.gnmi_ctl_set_and_verify(self.gnmictl_params):
             self.result.addFailure(self, sys.exc_info())
             self.fail("Failed to configure gnmi ctl ports")
@@ -143,7 +138,7 @@ class LNT_2vm_vxlan_2nsvm_5min_ping(BaseTest):
         ):
             self.result.addFailure(self, sys.exc_info())
             self.fail("Failed to generate P4C artifacts or pb.bin")
-
+            
         # set pipe line
         if not p4rt_ctl.p4rt_ctl_set_pipe(
             self.config_data["switch"],
@@ -358,7 +353,7 @@ class LNT_2vm_vxlan_2nsvm_5min_ping(BaseTest):
         log.info("close VM telnet session")
         for conn in self.conn_obj_list:
             conn.close()
-
+        
     def tearDown(self):
         log.info("Begin to teardown ...")
         log.info("Delete match action rules on local host")
@@ -389,11 +384,6 @@ class LNT_2vm_vxlan_2nsvm_5min_ping(BaseTest):
                 self.fail(
                     f"Failed to delete VM namesapce {namespace['name']} on {self.config_data['client_hostname']}"
                 )
-
-        # remove local bridge
-        if not ovs_utils.del_bridge_from_ovs(self.config_data["bridge"]):
-            self.result.addFailure(self, sys.exc_info())
-            self.fail(f"Failed to delete bridge {self.config_data['bridge']} from ovs")
 
         # remote bridge
         if not ovs_utils.del_bridge_from_ovs(

--- a/tests/lnt_4vm_2host_add_dele_rule.py
+++ b/tests/lnt_4vm_2host_add_dele_rule.py
@@ -54,7 +54,7 @@ class LNT_4VM_2host_add_del_rule(BaseTest):
 
         self.config_data = get_config_dict(
             config_json,
-            pci_bdf=test_params["pci_bdf"],
+            pci_bdf=test_params["lnt_pci_bdf"],
             vm_location_list=test_params["vm_location_list"],
             vm_cred=self.vm_cred,
             client_cred=test_params["client_cred"],
@@ -488,11 +488,6 @@ class LNT_4VM_2host_add_del_rule(BaseTest):
                 self.fail(
                     f"Failed to delete VM namesapce {namespace['name']} on {self.config_data['client_hostname']}"
                 )
-
-        # remove local bridge
-        if not ovs_utils.del_bridge_from_ovs(self.config_data["bridge"]):
-            self.result.addFailure(self, sys.exc_info())
-            self.fail(f"Failed to delete bridge {self.config_data['bridge']} from ovs")
 
         # remote remote bridge
         if not ovs_utils.del_bridge_from_ovs(

--- a/tests/lnt_4vm_on_same_host.py
+++ b/tests/lnt_4vm_on_same_host.py
@@ -185,11 +185,6 @@ class LNT_4VM_Same_Host(BaseTest):
             for del_action in table["del_action"]:
                 p4rt_ctl.p4rt_ctl_del_entry(table["switch"], table["name"], del_action)
 
-        # delete bridge
-        if not ovs_utils.del_bridge_from_ovs(self.config_data["bridge"]):
-            self.result.addFailure(self, sys.exc_info())
-            self.fail(f"Failed to delete bridge {self.config_data['bridge']} from ovs")
-
         # delete vlan
         for i in range(len(self.conn_obj_list)):
             id = self.config_data["port"][i]["vlan"]

--- a/tests/lnt_ctrl_vhost_port_flap.py
+++ b/tests/lnt_ctrl_vhost_port_flap.py
@@ -59,7 +59,7 @@ class LNT_Ctrl_Vhost_Port_Flap(BaseTest):
 
         self.config_data = get_config_dict(
             config_json,
-            pci_bdf=test_params["pci_bdf"],
+            pci_bdf=test_params["lnt_pci_bdf"],
             vm_location_list=test_params["vm_location_list"],
             vm_cred=self.vm_cred,
             client_cred=test_params["client_cred"],
@@ -471,12 +471,7 @@ class LNT_Ctrl_Vhost_Port_Flap(BaseTest):
                 self.fail(
                     f"Failed to delete VM namesapce {namespace['name']} on {self.config_data['client_hostname']}"
                 )
-
-        # remove local bridge
-        if not ovs_utils.del_bridge_from_ovs(self.config_data["bridge"]):
-            self.result.addFailure(self, sys.exc_info())
-            self.fail(f"Failed to delete bridge {self.config_data['bridge']} from ovs")
-
+                
         # remote remote bridge
         if not ovs_utils.del_bridge_from_ovs(
             self.config_data["bridge"],


### PR DESCRIPTION
Signed-off-by: Shujun Wang <shujun.wang@intel.com>

In corresponding to the change of test_to_run.txt, where the parameter "pci_bdf" is changed to "pci_bdf" and "lnt_pci_bdf", the config_data for pci_bdf in all LNT are changed to "lnt_pci_bdf".

The test log [TestingLog.txt](https://github.com/ipdk-io/ptf-tests/files/10362378/TestingLog.txt)
