### PR TITLE
changed path for setup_env.sh and set_hugepages.sh

### DIFF
--- a/pre_test.sh
+++ b/pre_test.sh
@@ -41,7 +41,7 @@ export LD_LIBRARY_PATH=$IPDK_RECIPE/install/lib/:$SDE_INSTALL/lib:$SDE_INSTALL/l
 export PATH=$PATH:$IPDK_RECIPE/install/bin:$DEPEND_INSTALL/bin:$DEPEND_INSTALL/sbin
 export RUN_OVS=$IPDK_RECIPE/install
 
-source $IPDK_RECIPE/scripts/dpdk/setup_env.sh $IPDK_RECIPE $SDE_INSTALL $DEPEND_INSTALL
+source $IPDK_RECIPE/install/sbin/setup_env.sh $IPDK_RECIPE $SDE_INSTALL $DEPEND_INSTALL
 
 echo "starting ovs"
 mkdir -p $IPDK_RECIPE/install/var/run/openvswitch
@@ -51,7 +51,7 @@ $IPDK_RECIPE/install/sbin/ovsdb-server  --remote=punix:$RUN_OVS/var/run/openvswi
 $IPDK_RECIPE/install/sbin/ovs-vswitchd --detach --no-chdir unix:$RUN_OVS/var/run/openvswitch/db.sock --mlockall --log-file=/tmp/ovs-vswitchd.log
 
 echo "set hugepages"
-$IPDK_RECIPE/scripts/dpdk/set_hugepages.sh
+$IPDK_RECIPE/install/sbin/set_hugepages.sh
 
 rm -rf /usr/share/stratum/dpdk/dpdk_skip_p4.conf
 cp common/p4c_artifacts/pna_tcp_connection_tracking/dpdk_skip_p4.conf /usr/share/stratum/dpdk/ 


### PR DESCRIPTION
Modified path for setup_env.sh and set_hugepages.sh to $IPDK_RECIPE/install/sbin

PTF script run log snippet:
=================
Setting PATH
OS and Version details...
Fedora : 33


Updated Environment Variables ...
SDE_INSTALL: /var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/install
DEPEND_INSTALL: /var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/deps
P4CP_INSTALL: /var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/ipdk-recipe/install
LIBRARY_PATH: /var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/deps/lib:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/deps/lib64:
LD_LIBRARY_PATH: /var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/deps/lib:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/deps/lib64:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/ipdk-recipe/install/lib:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/ipdk-recipe/install/lib64:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/ipdk-recipe/install/lib/:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/install/lib:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/install/lib64:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/deps/lib:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/deps/lib64:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/install/lib:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/install/lib64:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/install/lib64:/usr/local/lib:/usr/local/lib64
PATH: /var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/deps/bin:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/deps/sbin:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/ipdk-recipe/install/sbin:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/ipdk-recipe/install/bin:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/ipdk-recipe/install/bin:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/ipdk-recipe/install/sbin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/ipdk-recipe/install/bin:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/deps/bin:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/deps/sbin

Setting hugepages
1024
1024
starting ovs
set hugepages
Setting hugepages
1024
1024
run infrap4d
check if infrap4d is running
root 2934613 1 0 18:22 ? 00:00:00 /var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/ipdk-recipe/install/sbin/infrap4d
infrap4d Running
Using packet manipulation module: ptf.packet_scapy