### PR TITLE
Modified setup_env.sh arg

### DIFF
--- a/pre_test.sh
+++ b/pre_test.sh
@@ -41,7 +41,7 @@ export LD_LIBRARY_PATH=$IPDK_RECIPE/install/lib/:$SDE_INSTALL/lib:$SDE_INSTALL/l
 export PATH=$PATH:$IPDK_RECIPE/install/bin:$DEPEND_INSTALL/bin:$DEPEND_INSTALL/sbin
 export RUN_OVS=$IPDK_RECIPE/install
 
-source $IPDK_RECIPE/install/sbin/setup_env.sh $IPDK_RECIPE $SDE_INSTALL $DEPEND_INSTALL
+source $IPDK_RECIPE/install/sbin/setup_env.sh $IPDK_RECIPE/install $SDE_INSTALL $DEPEND_INSTALL
 
 echo "starting ovs"
 mkdir -p $IPDK_RECIPE/install/var/run/openvswitch


### PR DESCRIPTION
Modified setup_env.sh arg and gave $IPDK_RECIPE/install instead of $IPDK_RECIPE as $IPDK_RECIPE/install was given while building the recipe in CI
 
PTF script run Logs Snippet:
Running l2_exact_match_with_tap_port
13:21:59  
13:21:59  Killing qemu
13:21:59  killing infrap4d
13:21:59  Sleeping for 2 seconds
13:21:59  Killing ovs
13:21:59  sleeping for 2 seconds
13:21:59  Removing any vhost users from /tmp
13:21:59  Setting PATH
13:21:59  OS and Version details...
13:21:59  Fedora : 33
13:21:59  
13:21:59  
13:21:59  Updated Environment Variables ...
13:21:59  SDE_INSTALL: /var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/install
13:21:59  DEPEND_INSTALL: /var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/deps
13:21:59  P4CP_INSTALL: /var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/ipdk-recipe/install
13:21:59  LIBRARY_PATH: /var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/deps/lib:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/deps/lib64:
13:21:59  LD_LIBRARY_PATH: /var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/deps/lib:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/deps/lib64:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/ipdk-recipe/install/lib:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/ipdk-recipe/install/lib64:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/ipdk-recipe/install/lib/:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/install/lib:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/install/lib64:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/deps/lib:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/deps/lib64:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/install/lib:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/install/lib64:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/install/lib64:/usr/local/lib:/usr/local/lib64
13:21:59  PATH: /var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/deps/bin:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/deps/sbin:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/ipdk-recipe/install/sbin:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/ipdk-recipe/install/bin:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/ipdk-recipe/install/bin:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/ipdk-recipe/install/sbin:/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/ipdk-recipe/install/bin:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/deps/bin:/var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/deps/sbin
13:21:59  
13:21:59  Setting hugepages
13:21:59  1024
13:21:59  1024
13:21:59  starting ovs
13:21:59  set hugepages
13:21:59  Setting hugepages
13:21:59  1024
13:21:59  1024
13:21:59  run infrap4d
13:21:59  check if infrap4d is running
13:21:59  root 3514097 1 0 13:23 ? 00:00:00 /var/jenkins_agent/workspace/nex-epgsw-ipdkci/GitHub_MultiBranch_Pipelines/p4cp-ptf-tests/ipdk-recipe/install/sbin/infrap4d
13:21:59  infrap4d Running
13:21:59  Using packet manipulation module: ptf.packet_scapy
13:21:59  10/10/2023,13:23:14  PASSED: p4c --arch psa --target dpdk --output common/p4c_artifacts/l2_exact_match/pipe --p4runtime-files             common/p4c_artifacts/l2_exact_match/p4Info.txt --bf-rt-schema common/p4c_artifacts/l2_exact_match/bf-rt.json --context             common/p4c_artifacts/l2_exact_match/pipe/context.json common/p4c_artifacts/l2_exact_match/l2_exact_match.p4
13:21:59  10/10/2023,13:23:14  PASSED: cd common/p4c_artifacts/l2_exact_match; tdi_pipeline_builder --p4c_conf_file=l2_exact_match.conf             --bf_pipeline_config_binary_file=l2_exact_match.pb.bin
13:21:59  10/10/2023,13:23:14  PASSED: gnmi-ctl set "device:virtual-device,name:TAP0,pipeline-name:pipe,mempool-name:MEMPOOL0,mtu:2000,port-type:TAP"
13:21:59  10/10/2023,13:23:14  PASSED: gnmi-ctl set "device:virtual-device,name:TAP1,pipeline-name:pipe,mempool-name:MEMPOOL0,mtu:1500,port-type:TAP"
13:21:59  10/10/2023,13:23:14  PASSED: gnmi-ctl set "device:virtual-device,name:TAP2,pipeline-name:pipe,mempool-name:MEMPOOL0,mtu:1500,port-type:TAP"
13:21:59  10/10/2023,13:23:14  PASSED: gnmi-ctl set "device:virtual-device,name:TAP3,pipeline-name:pipe,mempool-name:MEMPOOL0,mtu:1500,port-type:TAP"
13:21:59  10/10/2023,13:23:16  PASSED: gnmi-ctl get verified for device:virtual-device,name:TAP0,pipeline-name:pipe,mempool-name:MEMPOOL0,mtu:2000,port-type:TAP
13:21:59  10/10/2023,13:23:16  PASSED: gnmi-ctl get verified for device:virtual-device,name:TAP1,pipeline-name:pipe,mempool-name:MEMPOOL0,mtu:1500,port-type:TAP
13:21:59  10/10/2023,13:23:16  PASSED: gnmi-ctl get verified for device:virtual-device,name:TAP2,pipeline-name:pipe,mempool-name:MEMPOOL0,mtu:1500,port-type:TAP
13:21:59  10/10/2023,13:23:16  PASSED: gnmi-ctl get verified for device:virtual-device,name:TAP3,pipeline-name:pipe,mempool-name:MEMPOOL0,mtu:1500,port-type:TAP
13:21:59  10/10/2023,13:23:16  PASSED: ip  link set TAP0 up
13:21:59  10/10/2023,13:23:16  PASSED: ip  addr add 1.1.1.1/24 dev TAP0
13:21:59  10/10/2023,13:23:16  PASSED: ip  link set TAP1 up
13:21:59  10/10/2023,13:23:16  PASSED: ip  addr add 2.2.2.2/24 dev TAP1
13:21:59  10/10/2023,13:23:16  PASSED: ip  link set TAP2 up
13:21:59  10/10/2023,13:23:16  PASSED: ip  addr add 0.0.0.0 dev TAP2
13:21:59  10/10/2023,13:23:16  PASSED: ip  link set TAP3 up
13:21:59  10/10/2023,13:23:16  PASSED: ip  addr add 0.0.0.0 dev TAP3
13:21:59  10/10/2023,13:23:16  PASSED: p4rt-ctl set pipe: common/p4c_artifacts/l2_exact_match/l2_exact_match.pb.bin
13:21:59  10/10/2023,13:23:16  INFO: Scenario : l2 exact match : table_for_dst_mac
13:21:59  10/10/2023,13:23:16  INFO: Adding table_for_dst_mac rules
13:21:59  10/10/2023,13:23:16  PASSED: p4rt-ctl add entry: headers.ethernet.dst_addr=00:00:01:00:00:01,action=ingress.send(0)
13:21:59  10/10/2023,13:23:16  PASSED: p4rt-ctl add entry: headers.ethernet.dst_addr=00:00:01:00:00:02,action=ingress.drop(1)
13:21:59  10/10/2023,13:23:16  INFO: sending packet to check if rule 1  hits
13:21:59  10/10/2023,13:23:16  PASSED: Verification of packets passed, packet received as per rule 1
13:21:59  10/10/2023,13:23:16  INFO: sending packet to check if rule2 hits
13:21:59  verifying packet on port device 0 port 9206
13:21:59  10/10/2023,13:23:16  PASSED: Verification of packets passed, packet dropped as per rule 2
13:21:59  10/10/2023,13:23:16  INFO: Scenario : l2 exact match : table_for_src_mac
13:21:59  10/10/2023,13:23:16  INFO: Adding table_for_src_mac rules
13:21:59  10/10/2023,13:23:16  PASSED: p4rt-ctl add entry: headers.ethernet.src_addr=00:00:01:00:00:01,action=ingress.send(0)
13:21:59  10/10/2023,13:23:16  PASSED: p4rt-ctl add entry: headers.ethernet.src_addr=00:00:01:00:00:02,action=ingress.drop(1)
13:21:59  10/10/2023,13:23:16  INFO: sending packet to check if rule 1  hits
13:21:59  10/10/2023,13:23:16  PASSED: Verification of packets passed, packet received as per rule 1
13:21:59  10/10/2023,13:23:16  INFO: sending packet to check if rule2 hits
13:21:59  verifying packet on port device 0 port 9206
13:21:59  10/10/2023,13:23:16  PASSED: Verification of packets passed, packet dropped as per rule 2
13:21:59  10/10/2023,13:23:16  INFO: Deleting rules
13:21:59  10/10/2023,13:23:16  INFO: Deleting table_for_dst_mac rules
13:21:59  10/10/2023,13:23:16  PASSED: p4rt-ctl del entry: headers.ethernet.dst_addr=00:00:01:00:00:01
13:21:59  10/10/2023,13:23:17  PASSED: p4rt-ctl del entry: headers.ethernet.dst_addr=00:00:01:00:00:02
13:21:59  10/10/2023,13:23:17  INFO: Deleting table_for_src_mac rules
13:21:59  10/10/2023,13:23:17  PASSED: p4rt-ctl del entry: headers.ethernet.src_addr=00:00:01:00:00:01
13:21:59  10/10/2023,13:23:17  PASSED: p4rt-ctl del entry: headers.ethernet.src_addr=00:00:01:00:00:02
13:21:59  10/10/2023,13:23:17  PASSED: Test has PASSED
13:21:59  
